### PR TITLE
SDD should be Engineered to be Progressive

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Delivery infrastructure is now programmable, and we will program it.
 -   **Modern programming languages:** Logic is best specified in code, not pictures or GUIs. Scripts don’t scale.
 -   **Model-based:** Backed by a model of the software domain, with understanding of code.
 -   **Testable:** Enabling short trips to spot errors before production.
--   **Progressive:** Separates code deployment from feature release to deliver changes quickly and safely to the correct audience.
+-   **Progressive:** Facilitates deployment at any time. With controlled, selective rollout of changes to audiences and environments. Allowing release to be gradual and deliberate.
 
 **Collaborative:** 
 -	**Among people:** Each person can express their expertise in code for everyone’s benefit.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Delivery infrastructure is now programmable, and we will program it.
 -   **Modern programming languages:** Logic is best specified in code, not pictures or GUIs. Scripts don’t scale.
 -   **Model-based:** Backed by a model of the software domain, with understanding of code.
 -   **Testable:** Enabling short trips to spot errors before production.
+-   **Progressive:** Separates code deployment from feature release to deliver changes quickly and safely to the correct audience.
 
 **Collaborative:** 
 -	**Among people:** Each person can express their expertise in code for everyone’s benefit.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Delivery infrastructure is now programmable, and we will program it.
 -   **Modern programming languages:** Logic is best specified in code, not pictures or GUIs. Scripts don’t scale.
 -   **Model-based:** Backed by a model of the software domain, with understanding of code.
 -   **Testable:** Enabling short trips to spot errors before production.
--   **Progressive:** Facilitates deployment at any time. With controlled, selective rollout of changes to audiences and environments. Allowing release to be gradual and deliberate.
+-   **Progressive:** Facilitates deployment at any time. Provides controlled, selective rollout of changes to audiences and environments. Allows release to be gradual and deliberate.
 
 **Collaborative:** 
 -	**Among people:** Each person can express their expertise in code for everyone’s benefit.


### PR DESCRIPTION
Recommending to add a statement to the **Engineered** section of SDD. A key distinction in modern application development is the ability to separate the act of deployment from the act of release. Ideally this is done in a progressive fashion that allows the owner of the release to limit the impact of changes in the case of canary deploys or percentage rollouts. 

Here are a few resources that speak to this at greater length:

https://redmonk.com/jgovernor/2018/08/06/towards-progressive-delivery/
https://blog.turbinelabs.io/deploy-not-equal-release-part-one-4724bc1e726b
https://launchdarkly.com/blog/progressive-delivery-a-history-condensed/